### PR TITLE
[RFC] Removed VPC resource dependency

### DIFF
--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -120,13 +120,6 @@ resource "aws_route_table" "internal" {
   }
 }
 
-resource "aws_route" "internal" {
-  count                  = "${length(compact(var.internal_subnets))}"
-  route_table_id         = "${element(aws_route_table.internal.*.id, count.index)}"
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(aws_nat_gateway.main.*.id, count.index)}"
-}
-
 /**
  * Route associations
  */


### PR DESCRIPTION
Every time we run terraform it tries to create 3 instances of this resource.

I believe we can just drop it and have successful applies from now on.

This is need because when we apply the changes on Circle CI (streethub-infrastructure repo) every build will be marked as failing due to terraform failing to instantiate this resources.