### PR TITLE
support ipv6 via dualstack prefix as recommended by amazon

### DIFF
--- a/web-service/elb/main.tf
+++ b/web-service/elb/main.tf
@@ -108,7 +108,7 @@ resource "aws_route53_record" "external" {
 
   alias {
     zone_id                = "${aws_elb.main.zone_id}"
-    name                   = "${aws_elb.main.dns_name}"
+    name                   = "dualstack.${aws_elb.main.dns_name}"
     evaluate_target_health = false
   }
 }
@@ -120,7 +120,7 @@ resource "aws_route53_record" "internal" {
 
   alias {
     zone_id                = "${aws_elb.main.zone_id}"
-    name                   = "${aws_elb.main.dns_name}"
+    name                   = "dualstack.${aws_elb.main.dns_name}"
     evaluate_target_health = false
   }
 }


### PR DESCRIPTION
Adds the dualstack alias prefix as recommended by Amazon 

We already have this prefix on the primary account aliases, this way we will match the production and staging aliases to also use this prefix

https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-internet-facing-load-balancers.html